### PR TITLE
Edited article function to append URL if doi is missing

### DIFF
--- a/bibliography/ams.bst
+++ b/bibliography/ams.bst
@@ -973,7 +973,12 @@ FUNCTION {article}
     }
   if$
   fin.article
-  write.doi
+  doi missing$
+    {  space write.url
+    }
+    {  write.doi
+    }
+  if$
 }
 
 FUNCTION {book}


### PR DESCRIPTION
I have some journal articles in my references that do not have a doi associated with them but are available online. I edited the article function to write out the URL only if the doi is missing to keep the reference lengths manageable since the doi is much more compact. It works fine in a WAF article I am editing.